### PR TITLE
Fix input styling, dark mode visibility, and timezone widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,9 +55,67 @@
                     <div class="card" style="max-width: 20rem;">
                         <div class="card-header m-4">World Time</div>
                         <div id="clockZones" class="card-body">
-                            <h5 class="card-title">Enter a region and city to get the current local time.</h5>
-                            <input class="placeholder mb-3" id="clock-region" type="text" placeholder="America" />
-                            <input id="clock-city" class="placeholder" type="text" placeholder="New_York" />
+                            <h5 class="card-title">Select a city to get the current local time.</h5>
+                            <select id="timezone-select" class="placeholder">
+                                <optgroup label="Americas">
+                                    <option value="America/New_York">New York (EST/EDT)</option>
+                                    <option value="America/Chicago">Chicago / Dallas / Houston (CST/CDT)</option>
+                                    <option value="America/Denver">Denver (MST/MDT)</option>
+                                    <option value="America/Los_Angeles">Los Angeles / Seattle (PST/PDT)</option>
+                                    <option value="America/Anchorage">Anchorage (AKST)</option>
+                                    <option value="Pacific/Honolulu">Honolulu (HST)</option>
+                                    <option value="America/Toronto">Toronto (EST/EDT)</option>
+                                    <option value="America/Vancouver">Vancouver (PST/PDT)</option>
+                                    <option value="America/Mexico_City">Mexico City (CST/CDT)</option>
+                                    <option value="America/Bogota">Bogota (COT)</option>
+                                    <option value="America/Lima">Lima (PET)</option>
+                                    <option value="America/Caracas">Caracas (VET)</option>
+                                    <option value="America/Santiago">Santiago (CLT)</option>
+                                    <option value="America/Sao_Paulo">São Paulo (BRT)</option>
+                                    <option value="America/Argentina/Buenos_Aires">Buenos Aires (ART)</option>
+                                </optgroup>
+                                <optgroup label="Europe">
+                                    <option value="Europe/London">London (GMT/BST)</option>
+                                    <option value="Europe/Lisbon">Lisbon (WET/WEST)</option>
+                                    <option value="Europe/Paris">Paris / Madrid / Rome (CET/CEST)</option>
+                                    <option value="Europe/Berlin">Berlin / Amsterdam (CET/CEST)</option>
+                                    <option value="Europe/Zurich">Zurich / Vienna (CET/CEST)</option>
+                                    <option value="Europe/Stockholm">Stockholm / Oslo (CET/CEST)</option>
+                                    <option value="Europe/Athens">Athens (EET/EEST)</option>
+                                    <option value="Europe/Helsinki">Helsinki (EET/EEST)</option>
+                                    <option value="Europe/Warsaw">Warsaw (CET/CEST)</option>
+                                    <option value="Europe/Istanbul">Istanbul (TRT)</option>
+                                    <option value="Europe/Moscow">Moscow (MSK)</option>
+                                </optgroup>
+                                <optgroup label="Africa">
+                                    <option value="Africa/Cairo">Cairo (EET)</option>
+                                    <option value="Africa/Casablanca">Casablanca (WET)</option>
+                                    <option value="Africa/Lagos">Lagos (WAT)</option>
+                                    <option value="Africa/Nairobi">Nairobi (EAT)</option>
+                                    <option value="Africa/Johannesburg">Johannesburg (SAST)</option>
+                                </optgroup>
+                                <optgroup label="Asia">
+                                    <option value="Asia/Dubai">Dubai (GST)</option>
+                                    <option value="Asia/Riyadh">Riyadh (AST)</option>
+                                    <option value="Asia/Karachi">Karachi (PKT)</option>
+                                    <option value="Asia/Kolkata">Mumbai / New Delhi (IST)</option>
+                                    <option value="Asia/Dhaka">Dhaka (BST)</option>
+                                    <option value="Asia/Bangkok">Bangkok / Jakarta (ICT)</option>
+                                    <option value="Asia/Singapore">Singapore (SGT)</option>
+                                    <option value="Asia/Hong_Kong">Hong Kong (HKT)</option>
+                                    <option value="Asia/Shanghai">Beijing / Shanghai (CST)</option>
+                                    <option value="Asia/Tokyo">Tokyo (JST)</option>
+                                    <option value="Asia/Seoul">Seoul (KST)</option>
+                                    <option value="Asia/Manila">Manila (PHT)</option>
+                                </optgroup>
+                                <optgroup label="Pacific">
+                                    <option value="Australia/Sydney">Sydney / Melbourne (AEST/AEDT)</option>
+                                    <option value="Australia/Brisbane">Brisbane (AEST)</option>
+                                    <option value="Australia/Perth">Perth (AWST)</option>
+                                    <option value="Pacific/Auckland">Auckland (NZST/NZDT)</option>
+                                    <option value="Pacific/Fiji">Fiji (FJT)</option>
+                                </optgroup>
+                            </select>
                             <button id="clockSearchBtn" class="btn btn-success my-2 my-sm-0 search" type="button">
                                 <i class="fas fa-search"></i>
                             </button>
@@ -139,9 +197,8 @@
                                 <option value="USD">United States Dollar (USD)</option>
                                 <option value="ZAR">South African Rand (ZAR)</option>
                             </select>
-                            <input id="currency-amount" type="number" min="0" />
-                            <br>
-                            <button id="convertBtn" type="button" class="btn btn-success ms-2 mt-3">Convert</button>
+                            <input id="currency-amount" type="number" min="0" placeholder="100" />
+                            <button id="convertBtn" type="button" class="btn btn-success ms-1 mt-2">Convert</button>
                         </div>
                     </div>
                 </div>

--- a/src/modules/timezone.js
+++ b/src/modules/timezone.js
@@ -1,9 +1,8 @@
 // World Time — uses timeapi.io (free, no API key required)
-// Input: region (e.g. "America") and city (e.g. "New_York")
+// Timezone values are valid IANA strings selected from the dropdown
 
 const clockSearchBtn = document.getElementById('clockSearchBtn');
-const clockRegionInput = document.getElementById('clock-region');
-const clockCityInput = document.getElementById('clock-city');
+const timezoneSelect = document.getElementById('timezone-select');
 const clockZones = document.getElementById('clockZones');
 
 function showTimeResult(html) {
@@ -18,33 +17,23 @@ function showTimeResult(html) {
 clockSearchBtn.addEventListener('click', async (event) => {
   event.preventDefault();
 
-  const region = clockRegionInput.value.trim();
-  const city = clockCityInput.value.trim();
-
-  if (!region || !city) {
-    showTimeResult('<li class="text-danger">Please enter both a region and a city.</li>');
-    return;
-  }
+  const timezone = timezoneSelect.value;
 
   showTimeResult('<li class="text-muted">Searching...</li>');
 
-  // Encode each part separately so the / remains a path separator
-  const timezone = `${encodeURIComponent(region)}/${encodeURIComponent(city)}`;
-
   try {
     const response = await fetch(
-      `https://timeapi.io/api/time/current/zone?timeZone=${timezone}`
+      `https://timeapi.io/api/time/current/zone?timeZone=${encodeURIComponent(timezone)}`
     );
 
     if (response.status === 400 || response.status === 404) {
-      showTimeResult(`<li class="text-danger">Timezone not found. Try "America" / "New_York" or "Europe" / "London".</li>`);
+      showTimeResult('<li class="text-danger">Timezone not found. Please select a city from the list.</li>');
       return;
     }
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
     const data = await response.json();
 
-    // timeapi.io returns dateTime as "2024-01-12T14:30:45.123"
     const dt = new Date(data.dateTime);
     const formattedTime = new Intl.DateTimeFormat('en-US', {
       timeZone: data.timeZone,

--- a/src/style.css
+++ b/src/style.css
@@ -17,9 +17,6 @@
     }
 }
 
-select {
-	margin: 10px;
-}
 
 .card {
     border: black solid 0px;
@@ -58,8 +55,30 @@ select {
     text-align: center;
 }
 
+input, select {
+    background-color: #ffffff !important;
+    color: #212529 !important;
+    border: 1px solid #ced4da !important;
+    border-radius: 4px;
+    outline: none;
+    width: 75%;
+    padding: 6px 10px;
+    margin: 6px auto 0;
+    box-sizing: border-box;
+    display: block;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus, select:focus {
+    border-color: #347B98 !important;
+    box-shadow: 0 0 0 3px rgba(52, 123, 152, 0.25);
+}
+
 #currency-amount {
-    margin-left: 10px;
+    width: 40%;
+    display: inline-block;
+    margin: 6px 0 0 12.5%;
+    vertical-align: middle;
 }
 
 


### PR DESCRIPTION
## Summary

- **Dark mode fix**: Added `!important` to background/color/border on all inputs and selects to override Bootstrap 5 CSS variables that were rendering dark backgrounds in dark mode
- **Consistent sizing**: All inputs and selects now share `width: 75%`, centered with uniform padding and `margin: 6px auto 0`
- **Focus ring**: Blue border + glow on focus using the existing `#347B98` accent color from the card header gradient
- **Timezone widget**: Replaced two free-text inputs (which caused 400 errors for any non-exact IANA string like "America/Dallas") with a dropdown of ~50 valid IANA timezones grouped by region. Updated `timezone.js` to read from the single select with proper URL encoding
- **Currency amount field**: Resized to 40% width, left-aligned to match the dropdowns above, inline with the Convert button. Removed the `<br>` layout hack

## Test plan

- [ ] All inputs show white background in both light and dark OS mode
- [ ] Inputs and selects are consistent in width and visually centered in each card
- [ ] Clicking any input shows blue focus ring
- [ ] World Time: selecting any city from the dropdown returns the correct local time
- [ ] Currency amount field is smaller and aligns with the selects above it
- [ ] All three widgets still return correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)