### PR TITLE
Add netlify.toml with explicit build config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "dist"


### PR DESCRIPTION
## Summary

Adds `netlify.toml` to explicitly define the Vite build command and publish directory. This was missing after the jQuery → Vite migration.

## The real fix for the Airport Finder 404

The API key lives in `.env` which is gitignored and never reaches Netlify. You need to add it manually in the Netlify dashboard:

1. Go to [Netlify Dashboard → traveladvisor → Site configuration → Environment variables](https://app.netlify.com/sites/traveladvisor/configuration/env)
2. Click **Add a variable**
3. Set key: `VITE_AIRPORT_API_KEY`
4. Set value: your RapidAPI key (same value as in your local `.env`)
5. Save and **trigger a redeploy**

Once the env var is set and the site redeploys, the Airport Finder will work in production.

## Test plan

- [ ] Netlify build completes using `npm run build` and serves from `dist/`
- [ ] After adding env var in Netlify dashboard: Airport Finder returns results on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)