### PR TITLE
Pin Node 20 in Netlify build environment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
 [build]
   command = "npm run build"
   publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "20"


### PR DESCRIPTION
## Summary

Fixes the Netlify build failure caused by Netlify defaulting to an old Node version that doesn't support optional chaining syntax (`?.`).

Vite 8 requires Node 18+. Adding `NODE_VERSION = "20"` to `netlify.toml` forces Netlify to use Node 20 LTS for all builds.

## Test plan

- [ ] Netlify build completes without SyntaxError
- [ ] Airport Finder works in production with the API key set in Netlify env vars
- [ ] All three widgets work on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)