### PR TITLE
feat: add Weather, Unit Converter, and Country Info widgets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,15 +13,18 @@ npm run preview  # preview the production build
 
 ## Architecture
 
-Single-page dashboard with three independent API-driven widgets. Each widget is an ES module in `src/modules/` that registers a click event listener and writes results into its own card div.
+Single-page dashboard with six independent API-driven widgets. Each widget is an ES module in `src/modules/` that registers a click event listener and writes results into its own card div.
 
 | Widget | Module | API |
 |---|---|---|
 | Airport Finder | `src/modules/airport.js` | `airport-info.p.rapidapi.com` — IATA code lookup (key in `.env`) |
 | World Time | `src/modules/timezone.js` | `timeapi.io/api/time/current/zone` — free, no key |
 | Currency Converter | `src/modules/currency.js` | `api.exchangerate-api.com/v4/latest` — free, no key, CORS-enabled |
+| Weather | `src/modules/weather.js` | `wttr.in/{city}?format=j1` — free, no key, returns temp/conditions/humidity/wind |
+| Unit Converter | `src/modules/converter.js` | No API — pure JS math (°C↔°F, km↔mi, kg↔lbs, L↔gal) |
+| Country Info | `src/modules/country.js` | `restcountries.com/v3.1/name/{name}` — free, no key, returns flag/capital/population/languages/currency |
 
-`src/main.js` is the Vite entry point — it only imports the three modules.
+`src/main.js` is the Vite entry point — it only imports the six modules.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ VITE_AIRPORT_API_KEY=your_rapidapi_key_here
 ```
 
 ## APIs
-Travel Advisor uses the following APIs to retrieve airport information, timezones, and currency exchange rates:
+Travel Advisor uses the following APIs:
 
 1. [Airport Info](https://rapidapi.com/Active-api/api/airport-info/) — Provides airport details by IATA code (e.g. DFW, JFK). Requires a RapidAPI key stored in `.env`.
 
@@ -45,14 +45,20 @@ Travel Advisor uses the following APIs to retrieve airport information, timezone
 
 3. [ExchangeRate API](https://www.exchangerate-api.com/) — Provides live currency exchange rates. Free, no API key required.
 
+4. [wttr.in](https://wttr.in/) — Provides current weather conditions by city name (temperature, description, humidity, wind). Free, no API key required.
+
+5. [REST Countries](https://restcountries.com/) — Provides country details by name (flag, capital, population, languages, currency, region). Free, no API key required.
+
+The Unit Converter widget requires no API — all conversions (°C↔°F, km↔mi, kg↔lbs, L↔gal) are computed locally.
+
 ## Accomplished
 
 > ~~Migrate from jQuery to vanilla JavaScript~~ — Completed. Migrated to vanilla JS ES modules with the Fetch API, replaced MomentJS with native `Intl.DateTimeFormat`, and upgraded Bootstrap 4 to Bootstrap 5.
 
 > ~~UI modernization~~ — Completed. Refreshed design with a cohesive color palette (coral-to-steel-blue card headers, ocean-tone body gradient), responsive card layout, improved input styling, and a clean SVG wave footer with API credits.
 
-## Future
+> ~~Weather widget~~ — Completed. Shows current conditions, temperature (°C/°F), feels-like, humidity, and wind speed for any city via wttr.in.
 
-> Implement MapQuest API to provide more accurate location data for airports and cities.
+> ~~Unit Converter widget~~ — Completed. Converts temperature, distance, weight, and volume using pure JS math — no API required.
 
-> Develop a Progressive Web App (PWA) version of Travel Advisor to allow users to access the app offline and enjoy a faster, more immersive experience.
+> ~~Country Info widget~~ — Completed. Shows flag, capital, region, population, languages, and currency for any country via REST Countries.

--- a/index.html
+++ b/index.html
@@ -200,6 +200,56 @@
                     </div>
                 </div>
 
+
+                <!-- WEATHER -->
+                <div class="col-12 col-md-6 col-lg-4 d-flex justify-content-center">
+                    <div class="card">
+                        <div class="card-header">Weather</div>
+                        <div id="weatherCard" class="card-body">
+                            <h5 class="card-title">Enter a city name to get the current weather.</h5>
+                            <input id="weatherCity" class="placeholder" type="text" placeholder="Paris" />
+                            <button id="weatherBtn" class="btn btn-success my-2 my-sm-0 search" type="button">
+                                <i class="fas fa-cloud-sun"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- UNIT CONVERTER -->
+                <div class="col-12 col-md-6 col-lg-4 d-flex justify-content-center">
+                    <div class="card">
+                        <div class="card-header">Unit Converter</div>
+                        <div id="converterCard" class="card-body">
+                            <h5 class="card-title">Convert between common travel units.</h5>
+                            <select id="converterCategory" class="placeholder">
+                                <option value="temperature">Temperature</option>
+                                <option value="distance">Distance</option>
+                                <option value="weight">Weight</option>
+                                <option value="volume">Volume</option>
+                            </select>
+                            <div class="d-flex justify-content-center align-items-center mt-2" style="gap: 6px;">
+                                <input id="converterInput" type="number" placeholder="0" style="width:45%; margin:0;" />
+                                <select id="converterUnit" style="width:35%; margin:0;"></select>
+                            </div>
+                            <button id="converterBtn" class="btn btn-success mt-2" type="button">Convert</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- COUNTRY INFO -->
+                <div class="col-12 col-md-6 col-lg-4 d-flex justify-content-center">
+                    <div class="card">
+                        <div class="card-header">Country Info</div>
+                        <div id="countryCard" class="card-body">
+                            <h5 class="card-title">Enter a country name to get key travel information.</h5>
+                            <input id="countryInput" class="placeholder" type="text" placeholder="Japan" />
+                            <button id="countryBtn" class="btn btn-success my-2 my-sm-0 search" type="button">
+                                <i class="fas fa-globe"></i>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
             </div>
         </main>
 
@@ -216,6 +266,10 @@
                     <a href="https://timeapi.io/" target="_blank" rel="noopener">TimeAPI</a>
                     <span class="footer-divider">|</span>
                     <a href="https://www.exchangerate-api.com/" target="_blank" rel="noopener">ExchangeRate API</a>
+                    <span class="footer-divider">|</span>
+                    <a href="https://wttr.in/" target="_blank" rel="noopener">wttr.in</a>
+                    <span class="footer-divider">|</span>
+                    <a href="https://restcountries.com/" target="_blank" rel="noopener">REST Countries</a>
                 </p>
                 <p>© Travel Advisor 2026. All rights reserved.</p>
             </div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,6 @@
 import './modules/airport.js';
 import './modules/timezone.js';
 import './modules/currency.js';
+import './modules/weather.js';
+import './modules/converter.js';
+import './modules/country.js';

--- a/src/modules/converter.js
+++ b/src/modules/converter.js
@@ -1,0 +1,76 @@
+// Unit Converter — pure JS, no API required
+// Categories: Temperature, Distance, Weight, Volume
+
+const converterBtn = document.getElementById('converterBtn');
+const converterCategory = document.getElementById('converterCategory');
+const converterInput = document.getElementById('converterInput');
+const converterUnit = document.getElementById('converterUnit');
+const converterCard = document.getElementById('converterCard');
+
+const units = {
+  temperature: ['°C', '°F'],
+  distance:    ['km', 'mi'],
+  weight:      ['kg', 'lbs'],
+  volume:      ['L', 'gal'],
+};
+
+function populateUnits() {
+  const category = converterCategory.value;
+  const options = units[category];
+  converterUnit.innerHTML = options
+    .map(u => `<option value="${u}">${u}</option>`)
+    .join('');
+}
+
+converterCategory.addEventListener('change', populateUnits);
+populateUnits();
+
+function convert(value, from, category) {
+  switch (category) {
+    case 'temperature':
+      if (from === '°C') return [{ label: '°F', value: (value * 9/5 + 32).toFixed(1) }];
+      return [{ label: '°C', value: ((value - 32) * 5/9).toFixed(1) }];
+    case 'distance':
+      if (from === 'km') return [{ label: 'mi', value: (value * 0.621371).toFixed(2) }];
+      return [{ label: 'km', value: (value * 1.60934).toFixed(2) }];
+    case 'weight':
+      if (from === 'kg') return [{ label: 'lbs', value: (value * 2.20462).toFixed(2) }];
+      return [{ label: 'kg', value: (value * 0.453592).toFixed(2) }];
+    case 'volume':
+      if (from === 'L') return [{ label: 'gal', value: (value * 0.264172).toFixed(2) }];
+      return [{ label: 'L', value: (value * 3.78541).toFixed(2) }];
+    default:
+      return [];
+  }
+}
+
+function showConverterResult(html) {
+  const existing = converterCard.querySelector('.converter-result');
+  if (existing) existing.remove();
+  const result = document.createElement('ul');
+  result.className = 'converter-result list-unstyled mt-2';
+  result.innerHTML = html;
+  converterCard.appendChild(result);
+}
+
+converterBtn.addEventListener('click', (event) => {
+  event.preventDefault();
+
+  const raw = converterInput.value.trim();
+  const value = parseFloat(raw);
+
+  if (!raw || isNaN(value)) {
+    showConverterResult('<li class="text-danger">Please enter a valid number.</li>');
+    return;
+  }
+
+  const category = converterCategory.value;
+  const from = converterUnit.value;
+  const results = convert(value, from, category);
+
+  const lines = results.map(r =>
+    `<li class="fw-bold">${value} ${from} = ${r.value} ${r.label}</li>`
+  ).join('');
+
+  showConverterResult(lines);
+});

--- a/src/modules/country.js
+++ b/src/modules/country.js
@@ -1,0 +1,63 @@
+// Country Info — uses restcountries.com (free, no API key required)
+// Accepts country name and returns flag, capital, population, languages, currency, region
+
+const countryBtn = document.getElementById('countryBtn');
+const countryInput = document.getElementById('countryInput');
+const countryCard = document.getElementById('countryCard');
+
+function showCountryResult(html) {
+  const existing = countryCard.querySelector('.country-result');
+  if (existing) existing.remove();
+  const result = document.createElement('ul');
+  result.className = 'country-result list-unstyled mt-2';
+  result.innerHTML = html;
+  countryCard.appendChild(result);
+}
+
+countryBtn.addEventListener('click', async (event) => {
+  event.preventDefault();
+
+  const name = countryInput.value.trim();
+  if (!name) {
+    showCountryResult('<li class="text-danger">Please enter a country name.</li>');
+    return;
+  }
+
+  showCountryResult('<li class="text-muted">Searching...</li>');
+
+  try {
+    const response = await fetch(
+      `https://restcountries.com/v3.1/name/${encodeURIComponent(name)}?fields=name,capital,population,languages,currencies,flags,region,subregion`
+    );
+
+    if (response.status === 404) {
+      showCountryResult('<li class="text-danger">Country not found. Check the spelling and try again.</li>');
+      return;
+    }
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+    const data = await response.json();
+    const c = data[0];
+
+    const flag = c.flags?.emoji ?? c.flags?.png ? `<img src="${c.flags.png}" alt="flag" style="height:16px;vertical-align:middle;margin-right:4px;">` : '';
+    const capital = c.capital?.[0] ?? 'N/A';
+    const population = c.population?.toLocaleString() ?? 'N/A';
+    const region = c.subregion ? `${c.subregion}, ${c.region}` : c.region;
+    const languages = c.languages ? Object.values(c.languages).join(', ') : 'N/A';
+    const currencies = c.currencies
+      ? Object.values(c.currencies).map(cu => `${cu.name} (${cu.symbol ?? ''})`).join(', ')
+      : 'N/A';
+
+    showCountryResult(`
+      <li class="fw-bold">${flag}${c.name.common}</li>
+      <li>Capital: ${capital}</li>
+      <li>Region: ${region}</li>
+      <li>Population: ${population}</li>
+      <li class="text-muted">Languages: ${languages}</li>
+      <li class="text-muted">Currency: ${currencies}</li>
+    `);
+  } catch (err) {
+    console.error('Country API error:', err);
+    showCountryResult('<li class="text-danger">Could not fetch country data. Please try again.</li>');
+  }
+});

--- a/src/modules/weather.js
+++ b/src/modules/weather.js
@@ -1,0 +1,61 @@
+// Weather — uses wttr.in (free, no API key required)
+// Accepts any city name and returns current conditions
+
+const weatherBtn = document.getElementById('weatherBtn');
+const weatherInput = document.getElementById('weatherCity');
+const weatherCard = document.getElementById('weatherCard');
+
+function showWeatherResult(html) {
+  const existing = weatherCard.querySelector('.weather-result');
+  if (existing) existing.remove();
+  const result = document.createElement('ul');
+  result.className = 'weather-result list-unstyled mt-2';
+  result.innerHTML = html;
+  weatherCard.appendChild(result);
+}
+
+weatherBtn.addEventListener('click', async (event) => {
+  event.preventDefault();
+
+  const city = weatherInput.value.trim();
+  if (!city) {
+    showWeatherResult('<li class="text-danger">Please enter a city name.</li>');
+    return;
+  }
+
+  showWeatherResult('<li class="text-muted">Fetching weather...</li>');
+
+  try {
+    const response = await fetch(
+      `https://wttr.in/${encodeURIComponent(city)}?format=j1`
+    );
+
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json();
+
+    const current = data.current_condition[0];
+    const area = data.nearest_area[0];
+    const cityName = area.areaName[0].value;
+    const country = area.country[0].value;
+    const desc = current.weatherDesc[0].value;
+    const tempC = current.temp_C;
+    const tempF = current.temp_F;
+    const humidity = current.humidity;
+    const windKmph = current.windspeedKmph;
+    const windMph = Math.round(windKmph * 0.621371);
+    const feelsC = current.FeelsLikeC;
+    const feelsF = current.FeelsLikeF;
+
+    showWeatherResult(`
+      <li class="fw-bold">${cityName}, ${country}</li>
+      <li>${desc}</li>
+      <li>${tempC}°C / ${tempF}°F</li>
+      <li class="text-muted">Feels like ${feelsC}°C / ${feelsF}°F</li>
+      <li class="text-muted">Humidity: ${humidity}%</li>
+      <li class="text-muted">Wind: ${windKmph} km/h / ${windMph} mph</li>
+    `);
+  } catch (err) {
+    console.error('Weather API error:', err);
+    showWeatherResult('<li class="text-danger">Could not fetch weather data. Please check the city name and try again.</li>');
+  }
+});


### PR DESCRIPTION
## Summary
Adds three new widgets to complete the Travel Advisor dashboard, bringing the total to six widgets across two rows.

- **Weather** — enter any city name to get current conditions, temperature (°C & °F), feels-like, humidity, and wind speed via [wttr.in](https://wttr.in/) (free, no API key)
- **Unit Converter** — pure JS conversion for temperature (°C↔°F), distance (km↔mi), weight (kg↔lbs), and volume (L↔gal). Category dropdown dynamically populates the unit select. No API call required.
- **Country Info** — enter any country name to get flag, capital, region, population, languages, and currency via [REST Countries](https://restcountries.com/) (free, no API key)

Footer updated with attribution links for wttr.in and REST Countries. CLAUDE.md and README.md updated to document all six widgets and APIs.

## Test plan
- [x] Weather: enter "Paris" → shows city, conditions, temp in both units, humidity, wind
- [x] Weather: enter a nonsense city → shows error message
- [x] Unit Converter: select Temperature, enter 100, select °C → shows 212.0°F
- [x] Unit Converter: change category to Distance → unit select updates to km/mi
- [x] Unit Converter: enter no value → shows error message
- [x] Country Info: enter "Japan" → shows flag, Tokyo, Eastern Asia, population, Japanese, Yen
- [x] Country Info: enter a misspelled country → shows not found error
- [x] Trigger one widget, confirm other five cards are unaffected
- [x] `npm run build` completes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)