### PR TITLE
fix: equal-height cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 
                         <!-- AIRPORT FINDER -->
                         <div class="col-12 col-md-6 col-lg-4 d-flex justify-content-center">
-                            <div class="card">
+                            <div class="card h-100 w-100">
                                 <div class="card-header">Airport Finder</div>
                                 <div id="airportNames" class="card-body">
                                     <h5 class="card-title">Enter a 3-letter IATA code.</h5>
@@ -70,7 +70,7 @@
 
                         <!-- WORLD TIME -->
                         <div class="col-12 col-md-6 col-lg-4 d-flex justify-content-center">
-                            <div class="card">
+                            <div class="card h-100 w-100">
                                 <div class="card-header">World Time</div>
                                 <div id="clockZones" class="card-body">
                                     <h5 class="card-title">Select a city for the current local time.</h5>
@@ -143,7 +143,7 @@
 
                         <!-- WEATHER -->
                         <div class="col-12 col-md-6 col-lg-4 d-flex justify-content-center">
-                            <div class="card">
+                            <div class="card h-100 w-100">
                                 <div class="card-header">Weather</div>
                                 <div id="weatherCard" class="card-body">
                                     <h5 class="card-title">Enter a city name for current conditions.</h5>
@@ -164,7 +164,7 @@
 
                         <!-- CURRENCY CONVERTER -->
                         <div class="col-12 col-md-6 col-lg-4 d-flex justify-content-center">
-                            <div class="card">
+                            <div class="card h-100 w-100">
                                 <div class="card-header">Currency Converter</div>
                                 <div id="currencyConv" class="card-body">
                                     <h5 class="card-title">Select currencies and enter an amount.</h5>
@@ -242,7 +242,7 @@
 
                         <!-- UNIT CONVERTER -->
                         <div class="col-12 col-md-6 col-lg-4 d-flex justify-content-center">
-                            <div class="card">
+                            <div class="card h-100 w-100">
                                 <div class="card-header">Unit Converter</div>
                                 <div id="converterCard" class="card-body">
                                     <h5 class="card-title">Convert between common travel units.</h5>
@@ -263,7 +263,7 @@
 
                         <!-- COUNTRY INFO -->
                         <div class="col-12 col-md-6 col-lg-4 d-flex justify-content-center">
-                            <div class="card">
+                            <div class="card h-100 w-100">
                                 <div class="card-header">Country Info</div>
                                 <div id="countryCard" class="card-body">
                                     <h5 class="card-title">Enter a country name for key travel info.</h5>


### PR DESCRIPTION
## Summary
- Adds `h-100 w-100` to all six cards so they stretch to equal height within each tab row
- Fixes Airport Finder appearing shorter than World Time and Weather

## Test plan
- [ ] All three cards on the Travel tab are the same height
- [ ] All three cards on the Reference tab are the same height

🤖 Generated with [Claude Code](https://claude.com/claude-code)